### PR TITLE
Add some basic instruction on how to run airrohr-mqtt with systemd

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,22 @@ $ cargo run
 ```
 By default it will listen to `localhost:8000`.
 
+
+## Running with Systemd
+
+One way to persist the execution, is to start it with systemd in the context of the current user. 
+An example configuration is provided in `airrohr-mqtt.service.EXAMPLE`.
+
+You want to copy this file to `~/.config/systemd/user/airrohr-mqtt.service`. Enable it with 
+`systemctl --user enable airrohr-mqtt.service`, start with 
+`systemctl --user start airrohr-mqtt.service`.
+
+Console output can be observed by `journalctl --user-unit airrohr-mqtt.service`. 
+
+In order to make it run, even when the user is not logged in, make sure to enable lingering. 
+You can use `loginctl`like so: `loginctl enable-linger`
+
+
 ## MQTT Integration
 
 The bridge publishes a device per Airrohr with all of its sensors with the following topics:

--- a/airrohr-mqtt.service.EXAMPLE
+++ b/airrohr-mqtt.service.EXAMPLE
@@ -1,0 +1,15 @@
+[Unit]
+Description=Brigde to provide Airrohr an API to deliver its data via MQTT to Homeassistant
+After=network.target
+
+[Service]
+Type=simple
+Environment="ROCKET_PORT=8008"
+Environment="ROCKET_ADDRESS=0.0.0.0"
+WorkingDirectory=/home/pi/airrohr-mqtt/
+ExecStart=/home/pi/.cargo/bin/cargo run
+CPUSchedulingPolicy=idle
+IOSchedulingClass=3
+
+[Install]
+WantedBy=default.target


### PR DESCRIPTION
This PR provides an example file for a configuration of a systemd user.unit and adds some instructions in the manual on how to use it.